### PR TITLE
Implemented JSON functions

### DIFF
--- a/Sources/SwifQL/Builders/With.swift
+++ b/Sources/SwifQL/Builders/With.swift
@@ -22,7 +22,7 @@ public class With: SwifQLable {
                     parts.append(o: .comma)
                     parts.append(o: .space)
                 }
-                parts += v.parts
+                parts.append(contentsOf: v.parts)
             }
             parts.append(o: .closeBracket)
         }
@@ -30,7 +30,7 @@ public class With: SwifQLable {
         parts.append(o: .as)
         parts.append(o: .space)
         parts.append(o: .openBracket)
-        parts += query.parts
+        parts.append(contentsOf: query.parts)
         parts.append(o: .closeBracket)
     }
 }

--- a/Sources/SwifQL/Functions.swift
+++ b/Sources/SwifQL/Functions.swift
@@ -849,15 +849,37 @@ extension Fn {
     
     /// Returns JSON value pointed to by path_elems (equivalent to #> operator)
     /// [Learn more →](https://www.postgresql.org/docs/current/functions-json.html)
-//    public static func json_extract_path(from_json : SwifQLable, path_elems: [String]) -> SwifQLable { // TBD
-//        return _buildFn(.json_extract_path, body: aggregateExpression.parts)
-//    }
+    public static func json_extract_path(_ from_json: SwifQLable, path_elems: [String]) -> SwifQLable {
+        var parts: [SwifQLPart] = from_json.parts
+        parts.append(o: .comma)
+        parts.append(o: .space)
+        for (i, v) in path_elems.enumerated() {
+            if i > 0 {
+                parts.append(o: .comma)
+                parts.append(o: .space)
+            }
+            parts.append(contentsOf: v.parts)
+        }
+        
+        return build(.json_extract_path, body: parts)
+    }
     
     /// Returns JSON value pointed to by path_elems as text (equivalent to #>> operator)
     /// [Learn more →](https://www.postgresql.org/docs/current/functions-json.html)
-//    public static func json_extract_path_text(from_json : SwifQLable, path_elems: [String]) -> SwifQLable { // TBD
-//        return _buildFn(.json_extract_path_text, body: aggregateExpression.parts)
-//    }
+    public static func json_extract_path_text(_ from_json: SwifQLable, path_elems: [String]) -> SwifQLable {
+        var parts: [SwifQLPart] = from_json.parts
+        parts.append(o: .comma)
+        parts.append(o: .space)
+        for (i, v) in path_elems.enumerated() {
+            if i > 0 {
+                parts.append(o: .comma)
+                parts.append(o: .space)
+            }
+            parts.append(contentsOf: v.parts)
+        }
+        
+        return build(.json_extract_path_text, body: parts)
+    }
     
     /// Returns set of keys in the outermost JSON object.
     /// [Learn more →](https://www.postgresql.org/docs/current/functions-json.html)
@@ -1028,15 +1050,37 @@ extension Fn {
     
     /// Returns JSON value pointed to by path_elems (equivalent to #> operator)
     /// [Learn more →](https://www.postgresql.org/docs/current/functions-json.html)
-//    public static func jsonb_extract_path(from_json : SwifQLable, path_elems: [String]) -> SwifQLable { // TBD
-//        return _buildFn(.jsonb_extract_path, body: aggregateExpression.parts)
-//    }
+    public static func jsonb_extract_path(_ from_json: SwifQLable, path_elems: [String]) -> SwifQLable {
+        var parts: [SwifQLPart] = from_json.parts
+        parts.append(o: .comma)
+        parts.append(o: .space)
+        for (i, v) in path_elems.enumerated() {
+            if i > 0 {
+                parts.append(o: .comma)
+                parts.append(o: .space)
+            }
+            parts.append(contentsOf: v.parts)
+        }
+        
+        return build(.jsonb_extract_path, body: parts)
+    }
     
     /// Returns JSON value pointed to by path_elems as text (equivalent to #>> operator)
     /// [Learn more →](https://www.postgresql.org/docs/current/functions-json.html)
-//    public static func jsonb_extract_path_text(from_json : SwifQLable, path_elems: [String]) -> SwifQLable { // TBD
-//        return _buildFn(.jsonb_extract_path_text, body: aggregateExpression.parts)
-//    }
+    public static func jsonb_extract_path_text(_ from_json: SwifQLable, path_elems: [String]) -> SwifQLable {
+        var parts: [SwifQLPart] = from_json.parts
+        parts.append(o: .comma)
+        parts.append(o: .space)
+        for (i, v) in path_elems.enumerated() {
+            if i > 0 {
+                parts.append(o: .comma)
+                parts.append(o: .space)
+            }
+            parts.append(contentsOf: v.parts)
+        }
+        
+        return build(.jsonb_extract_path_text, body: parts)
+    }
     
     /// Returns set of keys in the outermost JSON object.
     /// [Learn more →](https://www.postgresql.org/docs/current/functions-json.html)

--- a/Sources/SwifQL/Functions.swift
+++ b/Sources/SwifQL/Functions.swift
@@ -864,6 +864,10 @@ extension Fn {
         return build(.json_extract_path, body: parts)
     }
     
+    public static func json_extract_path(_ from_json: SwifQLable, path_elems: String...) -> SwifQLable {
+        json_extract_path(from_json, path_elems: path_elems)
+    }
+    
     /// Returns JSON value pointed to by path_elems as text (equivalent to #>> operator)
     /// [Learn more →](https://www.postgresql.org/docs/current/functions-json.html)
     public static func json_extract_path_text(_ from_json: SwifQLable, path_elems: [String]) -> SwifQLable {
@@ -879,6 +883,10 @@ extension Fn {
         }
         
         return build(.json_extract_path_text, body: parts)
+    }
+    
+    public static func json_extract_path_text(_ from_json: SwifQLable, path_elems: String...) -> SwifQLable {
+        json_extract_path_text(from_json, path_elems: path_elems)
     }
     
     /// Returns set of keys in the outermost JSON object.
@@ -1065,6 +1073,10 @@ extension Fn {
         return build(.jsonb_extract_path, body: parts)
     }
     
+    public static func jsonb_extract_path(_ from_json: SwifQLable, path_elems: String...) -> SwifQLable {
+        jsonb_extract_path(from_json, path_elems: path_elems)
+    }
+    
     /// Returns JSON value pointed to by path_elems as text (equivalent to #>> operator)
     /// [Learn more →](https://www.postgresql.org/docs/current/functions-json.html)
     public static func jsonb_extract_path_text(_ from_json: SwifQLable, path_elems: [String]) -> SwifQLable {
@@ -1080,6 +1092,10 @@ extension Fn {
         }
         
         return build(.jsonb_extract_path_text, body: parts)
+    }
+    
+    public static func jsonb_extract_path_text(_ from_json: SwifQLable, path_elems: String...) -> SwifQLable {
+        jsonb_extract_path_text(from_json, path_elems: path_elems)
     }
     
     /// Returns set of keys in the outermost JSON object.

--- a/Sources/SwifQL/KeyPath.swift
+++ b/Sources/SwifQL/KeyPath.swift
@@ -67,7 +67,7 @@ public prefix func => (rhs: String) -> SwifQLable {
 
 /// Getting keypath with alias
 /// e.g. you have `User` table with `email` field, and normally you can just write \User.email
-/// but in case of alias e.g. `let u = User.alias("u")` you should call it like `u+\.email`
+/// but in case of alias e.g. `let u = User.alias("u")` you should call it like `u~\.email`
 infix operator ~: AdditionPrecedence
 public func ~ <K, T, V>(lhs: SwifQLTableAlias<T>, rhs: K) -> AliasedKeyPath<K, T, V> where K: KeyPath<T, V>, K: Keypathable, T: Decodable {
     return AliasedKeyPath(lhs.alias, rhs)

--- a/Sources/SwifQL/SwifQLable+Parts/SwifQLable+With.swift
+++ b/Sources/SwifQL/SwifQLable+Parts/SwifQLable+With.swift
@@ -43,7 +43,7 @@ extension SwifQLable {
                 parts.append(o: .comma)
                 parts.append(o: .space)
             }
-            parts += v.parts
+            parts.append(contentsOf: v.parts)
         }
         return SwifQLableParts(parts: parts)
     }

--- a/Tests/SwifQLTests/SwifQLTests.swift
+++ b/Tests/SwifQLTests/SwifQLTests.swift
@@ -649,7 +649,7 @@ final class SwifQLTests: XCTestCase {
         checkAllDialects(query4, pg: pg4, mySQL: mySQL4)
     }
     
-    // MARK: - S?UBQUERY WITH ALIAS
+    // MARK: - SUBQUERY WITH ALIAS
     
     func testSubqueryWithAlias() {
         let a = CarBrands.as("a")
@@ -682,6 +682,56 @@ final class SwifQLTests: XCTestCase {
         """, mySQL: """
         SELECT a.name, (SELECT json_agg(alias1) as test1 FROM (SELECT b.name as someName FROM CarBrands AS b WHERE b.id = a.id) as alias1) FROM CarBrands AS a
         """)
+    }
+    
+    // MARK: - JSON
+    
+    func testJsonExtractPath() {
+        let json = #"{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}"#
+        let query = SwifQL.select(Fn.json_extract_path(json, path_elems: ["f4"]))
+        let pg = """
+        SELECT json_extract_path('{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}', 'f4')
+        """
+        let mySQL = """
+        SELECT json_extract_path('{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}', 'f4')
+        """
+        checkAllDialects(query, pg: pg, mySQL: mySQL)
+    }
+    
+    func testJsonExtractPathText() {
+        let json = #"{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}"#
+        let query = SwifQL.select(Fn.json_extract_path_text(json, path_elems: ["f4", "f6"]))
+        let pg = """
+        SELECT json_extract_path_text('{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}', 'f4', 'f6')
+        """
+        let mySQL = """
+        SELECT json_extract_path_text('{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}', 'f4', 'f6')
+        """
+        checkAllDialects(query, pg: pg, mySQL: mySQL)
+    }
+    
+    func testJsonbExtractPath() {
+        let json = #"{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}"#
+        let query = SwifQL.select(Fn.jsonb_extract_path(json, path_elems: ["f4"]))
+        let pg = """
+        SELECT jsonb_extract_path('{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}', 'f4')
+        """
+        let mySQL = """
+        SELECT jsonb_extract_path('{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}', 'f4')
+        """
+        checkAllDialects(query, pg: pg, mySQL: mySQL)
+    }
+    
+    func testJsonbExtractPathText() {
+        let json = #"{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}"#
+        let query = SwifQL.select(Fn.jsonb_extract_path_text(json, path_elems: ["f4", "f6"]))
+        let pg = """
+        SELECT jsonb_extract_path_text('{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}', 'f4', 'f6')
+        """
+        let mySQL = """
+        SELECT jsonb_extract_path_text('{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}', 'f4', 'f6')
+        """
+        checkAllDialects(query, pg: pg, mySQL: mySQL)
     }
     
     // MARK: - RETURNING
@@ -1034,6 +1084,10 @@ final class SwifQLTests: XCTestCase {
         ("testFn_to_tsvector", testFn_to_tsvector),
         ("testFn_to_tsquery", testFn_to_tsquery),
         ("testFn_plainto_tsquery", testFn_plainto_tsquery),
+        ("testJsonExtractPath", testJsonExtractPath),
+        ("testJsonExtractPathText", testJsonExtractPathText),
+        ("testJsonbExtractPath", testJsonbExtractPath),
+        ("testJsonbExtractPathText", testJsonbExtractPathText),
         ("testFormattedKeyPath", testFormattedKeyPath),
         ("testConcat", testConcat),
         ("testDelete", testDelete),


### PR DESCRIPTION
- Fix a couple `+= x.parts` with `.append(contentsOf: x.parts)` (from old PR I did) to stick with convention
- Implemented:
  - `Fn.json_extract_path`
  - `Fn.json_extract_path_text`
  - `Fn.jsonb_extract_path`
  - `Fn.jsonb_extract_path_text`
- Fix a couple typo's

If you would like me to change anything let me know 😃 