### PR TITLE
Add schema support

### DIFF
--- a/Sources/SwifQL/Column.swift
+++ b/Sources/SwifQL/Column.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  
-//
-//  Created by Mihael Isaev on 26.01.2020.
-//
-
-import Foundation

--- a/Sources/SwifQL/Dialect/Dialect+Postgres.swift
+++ b/Sources/SwifQL/Dialect/Dialect+Postgres.swift
@@ -8,7 +8,12 @@
 import Foundation
 
 class PostgreSQLDialect: SQLDialect {
-    override func tableName(_ value: String) -> String { value.doubleQuotted }
+    override func tableName(_ value: String, schema: String? = nil) -> String {
+        if let schema = schema {
+            return "\(schema.doubleQuotted).\(value.doubleQuotted)"
+        }
+        return value.doubleQuotted
+    }
     
     override func alias(_ value: String) -> String { value.doubleQuotted }
     

--- a/Sources/SwifQL/Dialect/Dialect.swift
+++ b/Sources/SwifQL/Dialect/Dialect.swift
@@ -27,7 +27,7 @@ open class SQLDialect {
         value ? "TRUE" : "FALSE"
     }
     
-    open func tableName(_ value: String) -> String { value }
+    open func tableName(_ value: String, schema: String? = nil) -> String { value }
     
     open func alias(_ value: String) -> String { value }
     
@@ -39,8 +39,8 @@ open class SQLDialect {
     
     open func jsonField(_ value: String) -> String { value }
     
-    open func tableName(_ tableName: String, andAlias alias: String) -> String {
-        self.tableName(tableName) + " AS " + self.alias(alias)
+    open func tableName(_ tableName: String, schema: String? = nil, andAlias alias: String) -> String {
+        self.tableName(tableName, schema: schema) + " AS " + self.alias(alias)
     }
     
     open func keyPath(_ keyPath: SwifQLPartKeyPath) -> String {

--- a/Sources/SwifQL/Extensions/Decodable+Table.swift
+++ b/Sources/SwifQL/Extensions/Decodable+Table.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Decodable {
     public static var table: SwifQLable {
         if let model = Self.self as? Tableable.Type {
-            return SwifQLableParts(parts: SwifQLPartTable(model.tableName))
+            return SwifQLableParts(parts: SwifQLPartTable(model.tableName, schema: model.schemaName))
         }
         return SwifQLableParts(parts: SwifQLPartTable(String(describing: Self.self)))
     }

--- a/Sources/SwifQL/FormattedKeyPath.swift
+++ b/Sources/SwifQL/FormattedKeyPath.swift
@@ -12,32 +12,37 @@ public typealias FKP = FormattedKeyPath
 
 public struct FormattedKeyPath {
     let _table: String
+    let _schema: String?
     let _paths: [String]
     
     public init <T: Tableable>(_ table: T.Type, _ paths: String...) {
         _table = table.tableName
+        _schema = table.schemaName
         _paths = paths
     }
     
     public init <T: Tableable>(_ table: T.Type, _ paths: [String]) {
         _table = table.tableName
+        _schema = table.schemaName
         _paths = paths
     }
     
-    public init (_ table: String, _ paths: String...) {
+    public init (_ table: String, _ schema: String? = nil, _ paths: String...) {
         _table = table
+        _schema = schema
         _paths = paths
     }
     
-    public init (_ table: String, _ paths: [String]) {
+    public init (_ table: String, _ schema: String? = nil, _ paths: [String]) {
         _table = table
+        _schema = schema
         _paths = paths
     }
 }
 
 extension FormattedKeyPath: SwifQLable {
     public var parts: [SwifQLPart] {
-        [SwifQLPartKeyPath(table: _table, paths: _paths)]
+        [SwifQLPartKeyPath(table: _table, schema: _schema, paths: _paths)]
     }
 }
 
@@ -53,7 +58,7 @@ extension Tableable {
     
     /// Manual key path. Alias to `\User.something`
     public static func manualKeyPath(_ paths: [String]) -> FormattedKeyPath {
-        FormattedKeyPath(tableName, paths)
+        FormattedKeyPath(tableName, schemaName, paths)
     }
     
     /// Manual key path. Alias to `\User.something`

--- a/Sources/SwifQL/Parts/KeyPathPart.swift
+++ b/Sources/SwifQL/Parts/KeyPathPart.swift
@@ -9,14 +9,16 @@ import Foundation
 
 public struct SwifQLPartKeyPath: SwifQLKeyPathable {
     public var table: String?
+    public var schema: String?
     public var paths: [String]
     public var asText: Bool
     // FIXME: instead of `asText` here create some protocol for path which will support `asText` for each part of path
-    public init (table: String? = nil, paths: String..., asText: Bool = false) {
-        self.init(table: table, paths: paths, asText: asText)
+    public init (table: String? = nil, schema: String? = nil, paths: String..., asText: Bool = false) {
+        self.init(table: table, schema: schema, paths: paths, asText: asText)
     }
-    public init (table: String? = nil, paths: [String], asText: Bool = false) {
+    public init (table: String? = nil, schema: String? = nil, paths: [String], asText: Bool = false) {
         self.table = table
+        self.schema = schema
         self.paths = paths
         self.asText = asText
     }

--- a/Sources/SwifQL/Parts/TablePart.swift
+++ b/Sources/SwifQL/Parts/TablePart.swift
@@ -9,7 +9,9 @@ import Foundation
 
 public struct SwifQLPartTable: SwifQLPart {
     public var table: String
-    public init (_ table: String) {
+    public var schema: String?
+    public init(_ table: String, schema: String? = nil) {
         self.table = table
+        self.schema = schema
     }
 }

--- a/Sources/SwifQL/Parts/TableWithAliasPart.swift
+++ b/Sources/SwifQL/Parts/TableWithAliasPart.swift
@@ -9,9 +9,11 @@ import Foundation
 
 public struct SwifQLPartTableWithAlias: SwifQLPart {
     public var table: String
+    public var schema: String?
     public var alias: String
-    public init (_ table: String, _ alias: String) {
+    public init (_ table: String, _ schema: String?, _ alias: String) {
         self.table = table
+        self.schema = schema
         self.alias = alias
     }
 }

--- a/Sources/SwifQL/Path/Path+Column.swift
+++ b/Sources/SwifQL/Path/Path+Column.swift
@@ -23,7 +23,7 @@ extension Path {
 
 extension Path.Column: SwifQLable {
     public var parts: [SwifQLPart] {
-        [SwifQLPartKeyPath(table: nil, paths: paths)]
+        [SwifQLPartKeyPath(table: nil, schema: nil, paths: paths)]
     }
 }
 

--- a/Sources/SwifQL/Path/Path+Table.swift
+++ b/Sources/SwifQL/Path/Path+Table.swift
@@ -10,8 +10,10 @@ import Foundation
 extension Path {
     public struct Table {
         public let name: String
+        public let schema: String?
         
-        public init (_ name: String) {
+        public init (_ name: String, schema: String? = nil) {
+            self.schema = schema
             self.name = name
         }
         
@@ -27,14 +29,14 @@ extension Path {
         
         @discardableResult
         public func column(_ paths: [String]) -> TableWithColumn {
-            TableWithColumn(table: name, paths: paths)
+            TableWithColumn(table: name, schema: schema, paths: paths)
         }
     }
 }
 
 extension Path.Table: SwifQLable {
     public var parts: [SwifQLPart] {
-        [SwifQLPartTable(name)]
+        [SwifQLPartTable(name, schema: schema)]
     }
 }
 

--- a/Sources/SwifQL/Path/Path+TableWithColumn.swift
+++ b/Sources/SwifQL/Path/Path+TableWithColumn.swift
@@ -10,13 +10,14 @@ import Foundation
 extension Path {
     public struct TableWithColumn {
         let table: String
+        let schema: String?
         let paths: [String]
     }
 }
 
 extension Path.TableWithColumn: SwifQLable {
     public var parts: [SwifQLPart] {
-        [SwifQLPartKeyPath(table: table, paths: paths)]
+        [SwifQLPartKeyPath(table: table, schema: schema, paths: paths)]
     }
 }
 

--- a/Sources/SwifQL/SwifQLTableAlias.swift
+++ b/Sources/SwifQL/SwifQLTableAlias.swift
@@ -19,7 +19,14 @@ public class SwifQLTableAlias<M: Decodable>: SwifQLable, SwifQLTableAliasable {
     }
     
     public var table: SwifQLable {
-        SwifQLableParts(parts: SwifQLPartTableWithAlias(name, alias))
+        SwifQLableParts(parts: SwifQLPartTableWithAlias(name, schema, alias))
+    }
+    
+    var schema: String? {
+        if let mmm = M.self as? Tableable.Type {
+            return mmm.schemaName
+        }
+        return nil
     }
     
     var name: String {
@@ -56,7 +63,7 @@ postfix public func *<T: Decodable>(table: SwifQLTableAlias<T>) -> SwifQLable {
 }
 postfix public func *(table: Tableable.Type) -> SwifQLable {
     var parts: [SwifQLPart] = []
-    parts.append(SwifQLPartTable(table.tableName))
+    parts.append(SwifQLPartTable(table.tableName, schema: table.schemaName))
     parts.append(o: .custom(".*"))
     parts.append(o: .space)
     return SwifQLableParts(parts: parts)

--- a/Sources/SwifQL/SwifQLable+Parts/SwifQLable+Table.swift
+++ b/Sources/SwifQL/SwifQLable+Parts/SwifQLable+Table.swift
@@ -15,12 +15,12 @@ extension SwifQLable {
         return SwifQLableParts(parts: parts)
     }
     
-    public func table(_ name: String) -> SwifQLable {
+    public func table(_ name: String, schema: String? = nil) -> SwifQLable {
         var parts: [SwifQLPart] = self.parts
         parts.appendSpaceIfNeeded()
         parts.append(o: .table)
         parts.append(o: .space)
-        parts.append(SwifQLPartTable(name))
+        parts.append(SwifQLPartTable(name, schema: schema))
         return SwifQLableParts(parts: parts)
     }
 }

--- a/Sources/SwifQL/SwifQLable.swift
+++ b/Sources/SwifQL/SwifQLable.swift
@@ -46,9 +46,17 @@ extension SwifQLable {
             case let v as SwifQLPartBool:
                 return dialect.boolValue(v.value)
             case let v as SwifQLPartTable:
-                return dialect.tableName(v.table)
+                if let schema = v.schema {
+                    return dialect.tableName(v.table, schema: schema)
+                } else {
+                    return dialect.tableName(v.table)
+                }
             case let v as SwifQLPartTableWithAlias:
-                return dialect.tableName(v.table, andAlias: v.alias)
+                if let schema = v.schema {
+                    return dialect.tableName(v.table, schema: schema, andAlias: v.alias)
+                } else {
+                    return dialect.tableName(v.table, andAlias: v.alias)
+                }
             case let v as SwifQLPartAlias:
                 return dialect.alias(v.alias)
             case let v as SwifQLPartKeyPath:

--- a/Sources/SwifQL/Table.swift
+++ b/Sources/SwifQL/Table.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  
-//
-//  Created by Mihael Isaev on 26.01.2020.
-//
-
-import Foundation

--- a/Sources/SwifQL/Tableable.swift
+++ b/Sources/SwifQL/Tableable.swift
@@ -11,6 +11,8 @@ public protocol Tableable: Codable {
     /// This model's unique name. By default, this property is set to a `String` describing the type.
     /// Override this property to change the model's table / collection name for all of Fluent.
     static var tableName: String { get }
+    
+    static var schemaName: String? { get }
 }
 
 // MARK: Optional
@@ -21,7 +23,11 @@ extension Tableable {
         String(describing: Self.self)
     }
     
+    public static var schemaName: String? {
+        nil
+    }
+    
     public static func column(_ paths: String...) -> Path.TableWithColumn {
-        Path.Table(tableName).column(paths)
+        Path.Table(tableName, schema: schemaName).column(paths)
     }
 }

--- a/Tests/SwifQLTests/SchemaTests.swift
+++ b/Tests/SwifQLTests/SchemaTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import SwifQL
+
+final class SchemaTests: SwifQLTestCase {
+    struct CarBrandss: Codable, Tableable {
+        static let schemaName: String? = "custom"
+        
+        var id: UUID
+        var name: String
+        var createdAt: Date
+    }
+    
+    func testSchema() {
+        let query = SwifQL.select(CarBrandss.table.*).from(CarBrandss.table)
+        
+        checkAllDialects(query, pg: """
+            SELECT "custom"."CarBrandss".* FROM "custom"."CarBrandss"
+            """, mySQL: """
+            SELECT CarBrandss.* FROM CarBrandss
+            """)
+    }
+    
+    static var allTests = [
+        ("testSchema", testSchema)
+    ]
+}

--- a/Tests/SwifQLTests/WhereTests.swift
+++ b/Tests/SwifQLTests/WhereTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import SwifQL
+
+final class WhereTests: SwifQLTestCase {
+    func testWhere() {
+        checkAllDialects(SwifQL.where("" == 1), pg: "WHERE '' = 1", mySQL: "WHERE '' = 1")
+        checkAllDialects(SwifQL.where, pg: "WHERE", mySQL: "WHERE")
+    }
+    
+    static var allTests = [
+        ("testWhere", testWhere)
+    ]
+}


### PR DESCRIPTION
PSQL (not sure about mysql) supports grouping tables into multiple schemas. As long as you dont have conflicting table names you dont need them, but if you ever use a Foreign Data Wrapper, you might not be able to control the table names. Then you would import them into a separate schema. And you need to prefix them with the schema name to access them (will default to public otherwise).

Thoughts on support for this?