### PR TITLE
Add MySQL specific function DATE_FORMAT

### DIFF
--- a/Sources/SwifQL/Functions.swift
+++ b/Sources/SwifQL/Functions.swift
@@ -168,6 +168,7 @@ extension Fn {
         // MARK: MySQL
         
         public static var from_unixtime: Name = .init("FROM_UNIXTIME")
+        static var date_format: Fn.Name = .init("DATE_FORMAT")
         
         // MARK: Custom
         
@@ -1844,6 +1845,25 @@ extension Fn {
             parts.append(o: .custom(format.singleQuotted))
         }
         return build(.from_unixtime, body: parts)
+    }
+
+    /// Formats the date value according to the format string.
+    /// # Example
+    /// ```swift
+    /// Fn.date_format(\User.createdAt, "%y-%m")
+    /// ```
+    /// # Result
+    /// ```
+    /// date_format("User"."createdAt", ""%y-%m"")
+    /// ```
+    /// [Learn more →](https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-format)
+    /// [Learn more →](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format)
+    static func date_format(_ datetime: SwifQLable, _ format: String) -> SwifQLable {
+        var parts: [SwifQLPart] = datetime.parts
+        parts.append(o: .comma)
+        parts.append(o: .space)
+        parts.append(o: .custom(format.singleQuotted))
+        return build(.date_format, body: parts)
     }
 }
 

--- a/Sources/SwifQL/Functions.swift
+++ b/Sources/SwifQL/Functions.swift
@@ -168,7 +168,7 @@ extension Fn {
         // MARK: MySQL
         
         public static var from_unixtime: Name = .init("FROM_UNIXTIME")
-        static var date_format: Fn.Name = .init("DATE_FORMAT")
+        public static var date_format: Name = .init("DATE_FORMAT")
         
         // MARK: Custom
         
@@ -1858,7 +1858,7 @@ extension Fn {
     /// ```
     /// [Learn more →](https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-format)
     /// [Learn more →](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format)
-    static func date_format(_ datetime: SwifQLable, _ format: String) -> SwifQLable {
+    public static func date_format(_ datetime: SwifQLable, _ format: String) -> SwifQLable {
         var parts: [SwifQLPart] = datetime.parts
         parts.append(o: .comma)
         parts.append(o: .space)

--- a/Tests/SwifQLTests/SwifQLTests.swift
+++ b/Tests/SwifQLTests/SwifQLTests.swift
@@ -876,6 +876,19 @@ final class SwifQLTests: XCTestCase {
         checkAllDialects(queryDate, pg: pgDate, mySQL: mySQLDate)
     }
 
+    // MARK: - MySQL DATE_FORMAT
+
+    func testFn_date_format() {
+        let query = SwifQL.select(Fn.date_format(CarBrands.column("createdAt"), "%y-%m"))
+        let pg = """
+        SELECT DATE_FORMAT("CarBrands"."createdAt", '%y-%m')
+        """
+        let mySQL = """
+        SELECT DATE_FORMAT(CarBrands.createdAt, '%y-%m')
+        """
+        checkAllDialects(query, pg: pg, mySQL: mySQL)
+    }
+
     static var allTests = [
         ("testPureSelect", testSelect),
         ("testSimpleString", testSelectString),
@@ -960,6 +973,7 @@ final class SwifQLTests: XCTestCase {
         ("testCaseWhenThenElse1", testCaseWhenThenElse1),
         ("testCaseWhenThenElse2", testCaseWhenThenElse2),
         ("testGenerateSeriesNumbers", testGenerateSeriesNumbers),
-        ("testGenerateSeriesDates", testGenerateSeriesDates)
+        ("testGenerateSeriesDates", testGenerateSeriesDates),
+        ("testFn_date_format", testFn_date_format)
     ]
 }


### PR DESCRIPTION
Utilizes MySQL's `DATE_FORMAT` function to operate on parts of a datestamp. Postgres have an equivalent `to_char`, if needed.

Note: I have to use it in a Vapor 3 project, hence the PR into v1 (I'll be happy to make similar PR into master as well)

links:
[MySQL 5.7 - DATE_FORMAT](https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-format)
[MySQL 8 -> DATE_FORMAT](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format)
[Postgres - to_char](https://www.techonthenet.com/postgresql/functions/to_char.php)