### PR TITLE
Add support for MySQL DATE_FORMAT

### DIFF
--- a/Sources/SwifQL/Functions/Functions+MySQL.swift
+++ b/Sources/SwifQL/Functions/Functions+MySQL.swift
@@ -7,6 +7,7 @@
 
 extension Fn.Name {
     public static var from_unixtime: Self = .init("FROM_UNIXTIME")
+    public static var date_format: Self = .init("DATE_FORMAT")
 }
 
 extension Fn {
@@ -18,5 +19,24 @@ extension Fn {
             parts.append(o: .custom(format.singleQuotted))
         }
         return build(.from_unixtime, body: parts)
+    }
+
+    /// Formats the date value according to the format string.
+    /// # Example
+    /// ```swift
+    /// Fn.date_format(\User.createdAt, "%y-%m")
+    /// ```
+    /// # Result
+    /// ```
+    /// date_format(User.createdAt, '%y-%m')
+    /// ```
+    /// [Learn more →](https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-format)
+    /// [Learn more →](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format)
+    public static func date_format(_ datetime: SwifQLable, _ format: String) -> SwifQLable {
+        var parts: [SwifQLPart] = datetime.parts
+        parts.append(o: .comma)
+        parts.append(o: .space)
+        parts.append(o: .custom(format.singleQuotted))
+        return build(.date_format, body: parts)
     }
 }

--- a/Tests/SwifQLTests/FnTests.swift
+++ b/Tests/SwifQLTests/FnTests.swift
@@ -120,6 +120,16 @@ final class FnTests: SwifQLTestCase {
             .mysql("SELECT generate_series(FROM_UNIXTIME(1569888000.0), FROM_UNIXTIME(1570147200.0), '1 day')")
         )
     }
+
+    // MARK: - MySQL DATE_FORMAT
+
+    func testFn_date_format() {
+        check(
+            SwifQL.select(Fn.date_format(CarBrands.column("createdAt"), "%y-%m")),
+            .psql(#"SELECT DATE_FORMAT("CarBrands"."createdAt", '%y-%m')"#),
+            .mysql("SELECT DATE_FORMAT(CarBrands.createdAt, '%y-%m')")
+        )
+    }
     
     static var allTests = [
         ("testFn_to_tsvector", testFn_to_tsvector),
@@ -127,6 +137,7 @@ final class FnTests: SwifQLTestCase {
         ("testFn_plainto_tsquery", testFn_plainto_tsquery),
         ("testConcat", testConcat),
         ("testGenerateSeriesNumbers", testGenerateSeriesNumbers),
-        ("testGenerateSeriesDates", testGenerateSeriesDates)
+        ("testGenerateSeriesDates", testGenerateSeriesDates),
+        ("testFn_date_format", testFn_date_format)
     ]
 }


### PR DESCRIPTION
Adds changes from #35 to the master branch

Utilizes MySQL's DATE_FORMAT function to operate on parts of a datestamp.

links:
MySQL 5.7 - DATE_FORMAT
MySQL 8 -> DATE_FORMAT
Postgres - to_char