### PR TITLE
Support Swift Data to PostgreSQL via decode function

### DIFF
--- a/Sources/SwifQL/Type+SwifQLable.swift
+++ b/Sources/SwifQL/Type+SwifQLable.swift
@@ -70,7 +70,7 @@ extension Data: SwifQLable {
         return [
             SwifQLPartOperator("decode"),
             SwifQLPartOperator.openBracket,
-            SwifQLPartUnsafeValue(base64EncodedString()),
+            SwifQLPartSafeValue(base64EncodedString()),
             SwifQLPartOperator.comma,
             SwifQLPartOperator.space,
             SwifQLPartSafeValue("base64"),

--- a/Sources/SwifQL/Type+SwifQLable.swift
+++ b/Sources/SwifQL/Type+SwifQLable.swift
@@ -65,6 +65,19 @@ extension Int64: SwifQLable {
 extension Date: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartDate(self)] }
 }
+extension Data: SwifQLable {
+    public var parts: [SwifQLPart] {
+        return [
+            SwifQLPartOperator("decode"),
+            SwifQLPartOperator.openBracket,
+            SwifQLPartUnsafeValue(base64EncodedString()),
+            SwifQLPartOperator.comma,
+            SwifQLPartOperator.space,
+            SwifQLPartSafeValue("base64"),
+            SwifQLPartOperator.closeBracket
+        ]
+    }
+}
 public protocol SwifQLRawRepresentable: RawRepresentable, SwifQLable {}
 extension SwifQLRawRepresentable {
     public var parts: [SwifQLPart] {

--- a/Tests/SwifQLTests/SelectTests.swift
+++ b/Tests/SwifQLTests/SelectTests.swift
@@ -30,6 +30,15 @@ final class SelectTests: SwifQLTestCase {
             .mysql("SELECT 1.234")
         )
     }
+
+    func testSelectData() {
+        let base64 = "Aa+/0w=="
+        let data = Data(base64Encoded: base64)!
+        check(
+            SwifQL.select(data),
+            .psql("SELECT decode('\(base64)', 'base64')")
+        )
+    }
     
     func testSelectSeveralSimpleValues() {
         check(


### PR DESCRIPTION
This is done via `decode(x, 'base64')`.

Base64 only uses alphanumerics and `+/=`, so no escaping should be required. And this is Base64, so no worry for SQL injection. This is why I use `SwifQLPartSafeValue`, but do correct me if I am wrong.

I only did the test for PostgreSQL, since as we discussed the whole thing is very different for MySQL.