### PR TITLE
feat(regex): Adds SwifQLRegex & SwifQLPartRegexValue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "SwifQL",
     platforms: [
-       .macOS(.v10_15)
+      .macOS(.v10_15), .iOS(.v12)
     ],
     products: [
         // 💎 Swift lib that gives an ability to build complex raw SQL-queries in strong-type declarative way

--- a/Sources/SwifQL/Builders/QueryBuilder.swift
+++ b/Sources/SwifQL/Builders/QueryBuilder.swift
@@ -7,9 +7,14 @@
 
 import Foundation
 
+// MARK: - Protocols
+
 public protocol QueryBuilderItemable {
     var values: [SwifQLable] { get }
 }
+
+// MARK: - Items
+
 public struct QueryBuilderItem: SwifQLable {
     public let parts: [SwifQLPart]
     public let values: [SwifQLable]
@@ -24,7 +29,10 @@ public struct QueryBuilderItem: SwifQLable {
         self.values = values ?? []
     }
 }
-@_functionBuilder public struct QueryBuilder {
+
+// MARK: - Builder
+
+@resultBuilder public struct QueryBuilder {
     public typealias Block = () -> SwifQLable
     
     /// Builds an empty view from an block containing no statements, `{ }`.

--- a/Sources/SwifQL/Dialect/Dialect.swift
+++ b/Sources/SwifQL/Dialect/Dialect.swift
@@ -7,68 +7,98 @@
 
 import Foundation
 
+
 open class SQLDialect {
-    open var id: String? { nil }
-    
+
+    // MARK: - Definitions
+
     public static var mysql: SQLDialect {
         MySQLDialect()
     }
-    
+
     public static var psql: SQLDialect {
         PostgreSQLDialect()
     }
-    
+
     public static var all: [SQLDialect] {
         [.psql, .mysql]
     }
-    
+
     /// Good choice only for super short and universal queries like `BEGIN;`, `ROLLBACK;`, `COMMIT;`
     public static var any: SQLDialect {
         .init()
     }
-    
-    init () {}
-    
-    open func boolValue(_ value: Bool) -> String {
-        value ? "TRUE" : "FALSE"
-    }
-    
+
+    // MARK: - Properties
+
+    open var id: String? { nil }
+
+    open var regexComponent: Bool = false
+    open var escapedComponent: Bool = false
+
+    // MARK: - Computed Properties
+
+    open var null: String { Operator.null._value }
+
     open var arrayStart: String { "" }
     open var emptyArrayStart: String { arrayStart }
-    
+
     open var arraySeparator: String { Operator.comma._value }
-    
+
     open var arrayEnd: String { "" }
     open var emptyArrayEnd: String { arrayEnd }
-    
+
+    open weak var regexDialect: Self? { Self.init(regex: true, escaped: escapedComponent) }
+    open weak var escapedDialect: Self? { Self.init(regex: regexComponent, escaped: true) }
+
+    // MARK: - Initializers
+
+    public required init (regex: Bool = false, escaped: Bool = false) {
+        self.regexComponent = regex
+        self.escapedComponent = escaped
+    }
+
+    // MARK: - Functions
+
+
     open func schemaName(_ value: String) -> String { value }
-    
+
     open func tableName(_ value: String) -> String { value }
-    
+
     open func alias(_ value: String) -> String { value }
-    
+
     open func column(_ value: String) -> String { value }
-    
+
     open func stringValue(_ value: String) -> String { value.singleQuotted }
-    
+
     open func uuidValue(_ value: UUID) -> String { stringValue(value.uuidString) }
-    
+
     open func jsonField(_ value: String) -> String { value }
-    
+
     open func tableName(_ tableName: String, andAlias alias: String) -> String {
         self.tableName(tableName) + " AS " + self.alias(alias)
     }
-    
+
     open func keyPath(_ keyPath: SwifQLPartKeyPath) -> String {
         "<key_path_should_be_here: override dialect function to fix>"
     }
-    
+
     open func date(_ value: Date) -> String {
         "<date_should_be_here: override dialect function to fix>"
     }
-    
-    open var null: String { "NULL" }
-    
+
+    open func boolValue(_ value: Bool) -> String { (value ? Operator.true : Operator.false)._value }
+
+    open func regexValue(_ value: Any?) -> String {
+        guard let value = value else { return null }
+        switch value {
+            case let v as String: return v
+            case let v as UUID: return v.uuidString
+            case let v as Bool: return boolValue(v)
+            default: return safeValue(value)
+        }
+    }
+
     open func safeValue(_ value: Any?) -> String {
         guard let value = value else { return null }
         switch value {
@@ -91,16 +121,19 @@ open class SQLDialect {
         default: return stringValue(String(describing: "<unsafe value>")) // TODO:
         }
     }
-    
+
     // MARK: - Binding (for formatter)
-    
+
     open var bindSymbol: String { "§§§" }
-    
+
     open func bindKey(_ i: Int) -> String { "?" }
+
 }
 
 extension SQLDialect: Equatable {
+
     public static func == (lhs: SQLDialect, rhs: SQLDialect) -> Bool {
         lhs.id == rhs.id
     }
+
 }

--- a/Sources/SwifQL/Operators.swift
+++ b/Sources/SwifQL/Operators.swift
@@ -12,7 +12,7 @@ public typealias Operator = SwifQLPartOperator
 
 extension SwifQLPartOperator {
     public typealias Result = SwifQLPartOperator
-    
+
     public static var left: Result { "LEFT".operator }
     public static var right: Result { "RIGHT".operator }
     public static var inner: Result { "INNER".operator }
@@ -187,8 +187,11 @@ extension SwifQLPartOperator {
     public static var data: Result { "DATA".operator }
     public static var partition: Result { "PARTITION".operator }
     public static var window: Result { "WINDOW".operator }
+    public static var `true`: Result { "TRUE".operator }
+    public static var `false`: Result { "FALSE".operator }
+
     public static func custom(_ v: String) -> Result { v.operator }
-    
+
     public var left: Result { concatWith(.left) }
     public var right: Result { concatWith(.right) }
     public var inner: Result { concatWith(.inner) }
@@ -363,13 +366,17 @@ extension SwifQLPartOperator {
     public var data: Result { concatWith(.data) }
     public var partition: Result { concatWith(.partition) }
     public var window: Result { concatWith(.window) }
+    public var `true`: Result { concatWith(.true) }
+    public var `false`: Result { concatWith(.false) }
     public func custom(_ v: String) -> Result { concatWith(.custom(v)) }
-    
+
     private func concatWith(_ operator: Result) -> Result {
         (_value + `operator`._value).operator
     }
 }
 
 extension String {
-    fileprivate var `operator`: SwifQLPartOperator { .init(self) }
+
+    public  var `operator`: SwifQLPartOperator { .init(self) }
+
 }

--- a/Sources/SwifQL/Parts/AliasPart.swift
+++ b/Sources/SwifQL/Parts/AliasPart.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public struct SwifQLPartAlias: SwifQLPart {
-    var alias: String
-    
+    public var alias: String
+
     init (_ alias: String) {
         self.alias = alias
     }

--- a/Sources/SwifQL/Parts/AliasPart.swift
+++ b/Sources/SwifQL/Parts/AliasPart.swift
@@ -14,3 +14,11 @@ public struct SwifQLPartAlias: SwifQLPart {
         self.alias = alias
     }
 }
+
+extension SwifQLPartAlias {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    return dialect.alias(alias)
+  }
+
+}

--- a/Sources/SwifQL/Parts/ArrayPart.swift
+++ b/Sources/SwifQL/Parts/ArrayPart.swift
@@ -10,3 +10,26 @@ import Foundation
 public protocol SwifQLPartArray: SwifQLPart {
     var elements: [SwifQLable] { get }
 }
+
+extension SwifQLPartArray {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    guard elements.count > 0 else {
+      return dialect.emptyArrayStart + dialect.emptyArrayEnd
+    }
+
+    var string = dialect.arrayStart
+
+    elements.enumerated().forEach { i, subPart in
+      if i > 0 { string += dialect.arraySeparator }
+      let prepared = subPart.prepare(dialect)
+
+      preparator._values.append(contentsOf: prepared._values)
+      preparator._formattedValues.append(contentsOf: prepared._formattedValues)
+      string += prepared._query
+    }
+
+    return string + dialect.arrayEnd
+  }
+
+}

--- a/Sources/SwifQL/Parts/BoolPart.swift
+++ b/Sources/SwifQL/Parts/BoolPart.swift
@@ -10,10 +10,10 @@ import Foundation
 public typealias SwifQLBool = SwifQLPartBool
 
 public struct SwifQLPartBool: SwifQLPart, SwifQLable {
+
+    public let value: Bool
     public var parts: [SwifQLPart] { [self] }
-    
-    let value: Bool
-    
+
     public init (_ value: Bool) {
         self.value = value
     }

--- a/Sources/SwifQL/Parts/BoolPart.swift
+++ b/Sources/SwifQL/Parts/BoolPart.swift
@@ -18,3 +18,11 @@ public struct SwifQLPartBool: SwifQLPart, SwifQLable {
         self.value = value
     }
 }
+
+extension SwifQLPartBool {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    return dialect.boolValue(value)
+  }
+
+}

--- a/Sources/SwifQL/Parts/ColumnPart.swift
+++ b/Sources/SwifQL/Parts/ColumnPart.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct SwifQLPartColumn: SwifQLPart {
     public var name: String
-    
+
     public init (_ name: String) {
         self.name = name
     }

--- a/Sources/SwifQL/Parts/ColumnPart.swift
+++ b/Sources/SwifQL/Parts/ColumnPart.swift
@@ -14,3 +14,11 @@ public struct SwifQLPartColumn: SwifQLPart {
         self.name = name
     }
 }
+
+extension SwifQLPartColumn {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    return dialect.column(name)
+  }
+
+}

--- a/Sources/SwifQL/Parts/DatePart.swift
+++ b/Sources/SwifQL/Parts/DatePart.swift
@@ -14,3 +14,11 @@ public struct SwifQLPartDate: SwifQLPart {
         self.date = date
     }
 }
+
+extension SwifQLPartDate {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    return dialect.date(date)
+  }
+
+}

--- a/Sources/SwifQL/Parts/DatePart.swift
+++ b/Sources/SwifQL/Parts/DatePart.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct SwifQLPartDate: SwifQLPart {
     public var date: Date
-    
+
     public init (_ date: Date) {
         self.date = date
     }

--- a/Sources/SwifQL/Parts/KeyPathPart.swift
+++ b/Sources/SwifQL/Parts/KeyPathPart.swift
@@ -8,22 +8,30 @@
 import Foundation
 
 public struct SwifQLPartKeyPath: SwifQLKeyPathable {
+
+    // MARK: - Properties
+
     public var schema: String?
     public var table: String?
     public var paths: [String]
     public var asText: Bool
+
+    // MARK: - Computed Properties
+
+    public var column: SwifQLPartColumn { .init(paths[0]) }
+
+    // MARK: - Initializers
+
     // FIXME: instead of `asText` here create some protocol for path which will support `asText` for each part of path
     public init (schema: String? = nil, table: String? = nil, paths: String..., asText: Bool = false) {
         self.init(schema: schema, table: table, paths: paths, asText: asText)
     }
+
     public init (schema: String? = nil, table: String? = nil, paths: [String], asText: Bool = false) {
         self.schema = schema
         self.table = table
         self.paths = paths
         self.asText = asText
-    }
-    public var column: SwifQLPartColumn {
-        .init(paths[0])
     }
 }
 

--- a/Sources/SwifQL/Parts/KeyPathPart.swift
+++ b/Sources/SwifQL/Parts/KeyPathPart.swift
@@ -40,3 +40,11 @@ extension SwifQLPartKeyPath: SwifQLable {
         SwifQLableParts(parts: self).parts
     }
 }
+
+extension SwifQLPartKeyPath {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    return dialect.keyPath(self)
+  }
+
+}

--- a/Sources/SwifQL/Parts/NullPart.swift
+++ b/Sources/SwifQL/Parts/NullPart.swift
@@ -13,3 +13,11 @@ public struct SwifQLPartNull: SwifQLPart, SwifQLable {
     public var parts: [SwifQLPart] { [self] }
     public init () {}
 }
+
+extension SwifQLPartNull {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    return dialect.null
+  }
+
+}

--- a/Sources/SwifQL/Parts/OperatorPart.swift
+++ b/Sources/SwifQL/Parts/OperatorPart.swift
@@ -18,3 +18,13 @@ public struct SwifQLPartOperator: SwifQLPart, Equatable {
 extension SwifQLPartOperator: SwifQLable {
     public var parts: [SwifQLPart] { [self] }
 }
+
+
+extension SwifQLPartOperator {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    return _value
+  }
+
+}
+

--- a/Sources/SwifQL/Parts/OperatorPart.swift
+++ b/Sources/SwifQL/Parts/OperatorPart.swift
@@ -8,15 +8,13 @@
 import Foundation
 
 public struct SwifQLPartOperator: SwifQLPart, Equatable {
-    var _value: String
-    
+    public var _value: String
+
     public init (_ value: String) {
         self._value = value
     }
 }
 
 extension SwifQLPartOperator: SwifQLable {
-    public var parts: [SwifQLPart] {
-        [self]
-    }
+    public var parts: [SwifQLPart] { [self] }
 }

--- a/Sources/SwifQL/Parts/RegexValuePart.swift
+++ b/Sources/SwifQL/Parts/RegexValuePart.swift
@@ -1,0 +1,176 @@
+//
+//  RegexValuePart.swift
+//  SwifQL
+//
+//  Created by Julien Di Marco on 04/02/2021.
+//
+
+import Foundation
+
+public struct SwifQLPartRegexValue {
+
+  var elements: [SwifQLable]
+
+  public init (_ elements: [SwifQLable]) {
+    self.elements = elements
+  }
+
+}
+
+extension SwifQLPartRegexValue: SwifQLable {
+
+  public var parts: [SwifQLPart] { [self] }
+
+}
+
+extension SwifQLPartRegexValue: SwifQLPart {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    var regexBuilder = ""
+    guard let regexDialect = dialect.regexDialect else { return "" }
+
+    elements.enumerated().forEach { i, v in
+      let prepared = v.prepare(regexDialect)
+      preparator._values.append(contentsOf: prepared._values)
+      preparator._formattedValues.append(contentsOf: prepared._formattedValues)
+      regexBuilder += prepared._query
+    }
+
+    return regexBuilder
+  }
+
+}
+
+// MARK: -
+
+extension SwifQLPartOperator {
+
+  public static var regexNotMatch: Result { "!~".operator }
+  public static var regexMatch: Result { "=~".operator }
+
+  public static var caret: Result { "^".operator }
+  public static var slash: Result { "/".operator }
+  public static var dollar: Result { "$".operator }
+
+  public static var pipe: Result { "|".operator }
+
+}
+
+// MARK: -
+
+public struct SwifQLRegex: SwifQLable {
+
+// MARK: - Properties
+
+internal var internals: [SwifQLPart]
+
+// MARK: - Computed Properties
+
+  public var parts: [SwifQLPart] {
+    var parts: [SwifQLPart] = []
+
+    parts.append(o: .slash)
+    parts += internals
+    parts.append(o: .slash)
+
+    return parts
+  }
+
+  // MARK: - Initializers
+
+  public init (_ parts: SwifQLPart...) {
+    self.init(parts)
+  }
+
+  public init (_ parts: [SwifQLPart]) {
+    self.internals = parts
+  }
+
+  public init (_ parts: SwifQLable...) {
+    self.init(parts)
+  }
+
+  public init (_ parts: [SwifQLable]) {
+    self.internals = [SwifQLPartRegexValue(parts)]
+  }
+
+}
+
+extension Array {
+
+  func insert(separator: Element) -> [Element] {
+    (0 ..< 2 * count - 1).map { $0 % 2 == 0 ? self[$0/2] : separator }
+  }
+
+}
+
+infix operator =~ : ComparisonPrecedence
+public func =~ (lhs: SwifQLable, rhs: SwifQLable) -> SwifQLable {
+  let regex = SwifQLRegex(rhs)
+  return SwifQLPredicate(operator: .regexMatch, lhs: lhs, rhs: regex)
+}
+
+public func =~ (lhs: SwifQLable, rhs: [SwifQLable]) -> SwifQLable {
+  let regex = SwifQLRegex(rhs.insert(separator: SwifQLPartOperator.pipe))
+  return SwifQLPredicate(operator: .regexMatch, lhs: lhs, rhs: regex)
+}
+
+infix operator !~ : ComparisonPrecedence
+public func !~ (lhs: SwifQLable, rhs: SwifQLable) -> SwifQLable {
+  let regex = SwifQLRegex(rhs)
+  return SwifQLPredicate(operator: .regexNotMatch, lhs: lhs, rhs: regex)
+}
+
+public func !~ (lhs: SwifQLable, rhs: [SwifQLable]) -> SwifQLable {
+  let regex = SwifQLRegex(rhs.insert(separator: SwifQLPartOperator.pipe))
+  return SwifQLPredicate(operator: .regexNotMatch, lhs: lhs, rhs: regex)
+}
+
+infix operator |: AdditionPrecedence
+public func | (lhs: SwifQLable, rhs: SwifQLable) -> SwifQLable {
+  return SwifQLPredicate(operator: .pipe, lhs: lhs, rhs: rhs)
+}
+
+// ^ Regex Operator
+prefix operator ^
+prefix public func ^(rhs: SwifQLable) -> SwifQLable {
+  var parts: [SwifQLPart] = []
+  parts.append(o: .caret)
+  parts.append(contentsOf: rhs.parts)
+  return SwifQLableParts(parts: parts)
+}
+
+prefix public func ^(rhs: [SwifQLable]) -> SwifQLable {
+  var parts: [SwifQLPart] = []
+  parts.append(o: .caret)
+  parts.append(contentsOf: rhs.flatMap({ $0.parts }))
+  return SwifQLableParts(parts: parts)
+}
+
+// $ Regex Operator
+postfix operator ^
+postfix public func ^(lhs: SwifQLable) -> SwifQLable {
+  var parts: [SwifQLPart] = []
+  parts.append(contentsOf: lhs.parts)
+  parts.append(o: .dollar)
+  return SwifQLableParts(parts: parts)
+}
+
+postfix public func ^(lhs: [SwifQLable]) -> SwifQLable {
+  var parts: [SwifQLPart] = []
+  parts.append(contentsOf: lhs.flatMap({ $0.parts }))
+  parts.append(o: .dollar)
+  return SwifQLableParts(parts: parts)
+}
+
+postfix operator ||
+postfix public func ||(lhs: [SwifQLable]) -> SwifQLable {
+  let transformed = lhs.insert(separator: SwifQLPartOperator.pipe)
+  return SwifQLableParts(parts: transformed.flatMap({ $0.parts }))
+}
+
+/// No Specific operator for AND comparison, could do (SwifQable) foreach elemnent
+//postfix operator &&
+//postfix public func &&(lhs: [SwifQLable]) -> SwifQLable {
+//  return SwifQLableParts(parts: rhs.insert(separator: SwifQLPartOperator.pipe))
+//}

--- a/Sources/SwifQL/Parts/SafeValuePart.swift
+++ b/Sources/SwifQL/Parts/SafeValuePart.swift
@@ -14,3 +14,12 @@ public struct SwifQLPartSafeValue: SwifQLPart {
         safeValue = value
     }
 }
+
+
+extension SwifQLPartSafeValue {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    return dialect.safeValue(safeValue)
+  }
+
+}

--- a/Sources/SwifQL/Parts/SafeValuePart.swift
+++ b/Sources/SwifQL/Parts/SafeValuePart.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public struct SwifQLPartSafeValue: SwifQLPart {
-    var safeValue: Any?
-    
+    public var safeValue: Any?
+
     public init (_ value: Any?) {
         safeValue = value
     }

--- a/Sources/SwifQL/Parts/TablePart.swift
+++ b/Sources/SwifQL/Parts/TablePart.swift
@@ -8,18 +8,23 @@
 import Foundation
 
 public struct SwifQLPartSchema: SwifQLPart {
+
     public var schema: String?
+
     public init (_ schema: String?) {
         self.schema = schema
     }
 }
 
 public struct SwifQLPartTable: SwifQLPart {
-    public var schema: String?
+
     public var table: String
+    public var schema: String?
+
     public init (_ table: String) {
         self.table = table
     }
+
     public init (schema: String?, table: String) {
         self.schema = schema
         self.table = table

--- a/Sources/SwifQL/Parts/TablePart.swift
+++ b/Sources/SwifQL/Parts/TablePart.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// MARK: Schema Part
+
 public struct SwifQLPartSchema: SwifQLPart {
 
     public var schema: String?
@@ -15,6 +17,17 @@ public struct SwifQLPartSchema: SwifQLPart {
         self.schema = schema
     }
 }
+
+extension SwifQLPartSchema {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    guard let schema = schema else { return "" }
+    return dialect.schemaName(schema)
+  }
+
+}
+
+// MARK: - Table Part
 
 public struct SwifQLPartTable: SwifQLPart {
 
@@ -29,4 +42,13 @@ public struct SwifQLPartTable: SwifQLPart {
         self.schema = schema
         self.table = table
     }
+}
+
+extension SwifQLPartTable {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    guard let schema = schema else { return dialect.tableName(table) }
+    return dialect.schemaName(schema) + "." + dialect.tableName(table)
+  }
+
 }

--- a/Sources/SwifQL/Parts/TableWithAliasPart.swift
+++ b/Sources/SwifQL/Parts/TableWithAliasPart.swift
@@ -17,3 +17,12 @@ public struct SwifQLPartTableWithAlias: SwifQLPart {
         self.alias = alias
     }
 }
+
+extension SwifQLPartTableWithAlias {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    guard let schema = schema else { return dialect.tableName(table, andAlias: alias) }
+    return dialect.schemaName(schema) + "." + dialect.tableName(table, andAlias: alias)
+  }
+
+}

--- a/Sources/SwifQL/Parts/TableWithAliasPart.swift
+++ b/Sources/SwifQL/Parts/TableWithAliasPart.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct SwifQLPartTableWithAlias: SwifQLPart {
     public var schema: String?
     public var table, alias: String
-    
+
     public init (schema: String?, table: String, alias: String) {
         self.schema = schema
         self.table = table

--- a/Sources/SwifQL/Parts/UnsafeValuePart.swift
+++ b/Sources/SwifQL/Parts/UnsafeValuePart.swift
@@ -14,3 +14,13 @@ public struct SwifQLPartUnsafeValue: SwifQLPart {
         unsafeValue = value
     }
 }
+
+extension SwifQLPartUnsafeValue {
+
+  public func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String {
+    preparator._values.append(unsafeValue)
+    preparator._formattedValues.append(dialect.safeValue(unsafeValue))
+    return dialect.bindSymbol
+  }
+
+}

--- a/Sources/SwifQL/Parts/UnsafeValuePart.swift
+++ b/Sources/SwifQL/Parts/UnsafeValuePart.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public struct SwifQLPartUnsafeValue: SwifQLPart {
-    var unsafeValue: Encodable
-    
+   public var unsafeValue: Encodable
+
     public init (_ value: Encodable) {
         unsafeValue = value
     }

--- a/Sources/SwifQL/Prepared.swift
+++ b/Sources/SwifQL/Prepared.swift
@@ -8,28 +8,46 @@
 import Foundation
 
 public struct SwifQLPrepared {
-    var _dialect: SQLDialect
-    var _query: String
-    var _values: [Encodable]
-    var _formattedValues: [String]
-    
-    init (dialect: SQLDialect, query: String, values: [Encodable], formattedValues: [String]) {
+
+  // MARK: - Properties
+
+    public var _dialect: SQLDialect
+    public var _query: String
+    public var _values: [Encodable]
+    public var _formattedValues: [String]
+
+
+  // MARK: - Computed Properties
+
+  public var plain: String {
+    guard _values.count > 0 else { return _query }
+    let formatter = SwifQLFormatter(_dialect, mode: .plain)
+    return formatter.string(from: _query, with: _formattedValues)
+  }
+
+  public var splitted: SwifQLSplittedQuery {
+    guard _values.count > 0 else { return .init(query: _query, values: _values) }
+    let formatter = SwifQLFormatter(_dialect, mode: .binded)
+    let result = formatter.string(from: _query, with: _formattedValues)
+    return .init(query: result, values: _values)
+  }
+
+  // MARK: - Initialiers
+
+    public init(dialect: SQLDialect, query: String = "", values: [Encodable] = [], formattedValues: [String] = []) {
         _dialect = dialect
         _query = query
         _values = values
         _formattedValues = formattedValues
     }
-    
-    public var plain: String {
-        guard _values.count > 0 else { return _query }
-        let formatter = SwifQLFormatter(_dialect, mode: .plain)
-        return formatter.string(from: _query, with: _formattedValues)
-    }
-    
-    public var splitted: SwifQLSplittedQuery {
-        guard _values.count > 0 else { return .init(query: _query, values: _values) }
-        let formatter = SwifQLFormatter(_dialect, mode: .binded)
-        let result = formatter.string(from: _query, with: _formattedValues)
-        return .init(query: result, values: _values)
-    }
+
+  // MARK: - Prepare
+
+  public init(_ container: SwifQLable, _ dialect: SQLDialect) {
+    self.init(dialect: dialect)
+    self._query = container.parts.map({ return $0.prepare(dialect, preparator: &self)}).joined()
+  }
+
 }
+
+

--- a/Sources/SwifQL/QueryBuilderable.swift
+++ b/Sources/SwifQL/QueryBuilderable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol QueryBuilderable: class {
+public protocol QueryBuilderable: AnyObject {
     var queryParts: QueryParts { get set }
 }
 

--- a/Sources/SwifQL/SwifQLable.swift
+++ b/Sources/SwifQL/SwifQLable.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// MARK: - SwifQLable Protocols
+
 public protocol SwifQLable: CustomStringConvertible {
     var parts: [SwifQLPart] { get }
 }
@@ -15,17 +17,17 @@ extension SwifQLable {
     public var description: String { prepare(.psql).plain }
 }
 
-public struct SwifQLableParts: SwifQLable {
-    public var parts: [SwifQLPart]
-    public init (parts: SwifQLPart...) {
-        self.init(parts: parts)
-    }
-    public init (parts: [SwifQLPart]) {
-        self.parts = parts
-    }
+// MARK: - SwifQLPart Protocols
+
+public protocol SwifQLPart {
+    func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String
 }
 
-public protocol SwifQLPart {}
+public extension SwifQLPart {
+    func prepare(_ dialect: SQLDialect, preparator: inout SwifQLPrepared) -> String { return "" }
+}
+
+// MARK: - SwifQLKeyPathable Protocols
 
 public protocol SwifQLKeyPathable: SwifQLPart {
     var schema: String? { get }
@@ -34,67 +36,30 @@ public protocol SwifQLKeyPathable: SwifQLPart {
 }
 
 extension SwifQLable {
+
     /// Good choice only for super short and universal queries like `BEGIN;`, `ROLLBACK;`, `COMMIT;`
     public func prepare() -> SwifQLPrepared {
         prepare(.any)
     }
-    
+
     public func prepare(_ dialect: SQLDialect) -> SwifQLPrepared {
-        var values: [Encodable] = []
-        var formattedValues: [String] = []
-        let query = parts.map { part in
-            switch part {
-            case let v as SwifQLPartArray:
-                guard v.elements.count > 0 else {
-                    return dialect.emptyArrayStart + dialect.emptyArrayEnd
-                }
-                var string = dialect.arrayStart
-                v.elements.enumerated().forEach { i, v in
-                    if i > 0 {
-                        string += dialect.arraySeparator
-                    }
-                    let prepared = v.prepare(dialect)
-                    values.append(contentsOf: prepared._values)
-                    formattedValues.append(contentsOf: prepared._formattedValues)
-                    string += prepared._query
-                }
-                return string + dialect.arrayEnd
-            case let v as SwifQLPartBool:
-                return dialect.boolValue(v.value)
-            case is SwifQLPartNull:
-                return dialect.null
-            case let v as SwifQLPartSchema:
-                guard let schema = v.schema else { return "" }
-                return dialect.schemaName(schema)
-            case let v as SwifQLPartTable:
-                if let schema = v.schema {
-                    return dialect.schemaName(schema) + "." + dialect.tableName(v.table)
-                }
-                return dialect.tableName(v.table)
-            case let v as SwifQLPartTableWithAlias:
-                if let schema = v.schema {
-                    return dialect.schemaName(schema) + "." + dialect.tableName(v.table, andAlias: v.alias)
-                }
-                return dialect.tableName(v.table, andAlias: v.alias)
-            case let v as SwifQLPartAlias:
-                return dialect.alias(v.alias)
-            case let v as SwifQLPartKeyPath:
-                return dialect.keyPath(v)
-            case let v as SwifQLPartColumn:
-                return dialect.column(v.name)
-            case let v as SwifQLPartOperator:
-                return v._value
-            case let v as SwifQLPartDate:
-                return dialect.date(v.date)
-            case let v as SwifQLPartSafeValue:
-                return dialect.safeValue(v.safeValue)
-            case let v as SwifQLPartUnsafeValue:
-                values.append(v.unsafeValue)
-                formattedValues.append(dialect.safeValue(v.unsafeValue))
-                return dialect.bindSymbol
-            default: return ""
-            }
-        }.joined(separator: "")
-        return .init(dialect: dialect, query: query, values: values, formattedValues: formattedValues)
+      return SwifQLPrepared(self, dialect)
     }
+
 }
+
+// MARK: - SwifQLableParts
+
+public struct SwifQLableParts: SwifQLable {
+
+    // MARK: - Properties
+
+    public var parts: [SwifQLPart]
+
+    // MARK: - Initializers
+
+    public init (parts: [SwifQLPart]) { self.parts = parts }
+    public init (parts: SwifQLPart...) { self.init(parts: parts) }
+
+}
+

--- a/Sources/SwifQL/Type+SwifQLable.swift
+++ b/Sources/SwifQL/Type+SwifQLable.swift
@@ -7,64 +7,72 @@
 
 import Foundation
 
-extension Optional: SwifQLable, CustomStringConvertible where Wrapped: SwifQLable {
-    public var parts: [SwifQLPart] {
-        switch self {
-        case .none:
-            return [SwifQLPartSafeValue(nil)]
-        case .some(let value):
-            return value.parts
-        }
-    }
-}
+// MARK: - Types
+
 extension String: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension UUID: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension Decimal: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension Double: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension Float: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension UInt: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension UInt8: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension UInt16: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension UInt32: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension UInt64: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension Int: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension Int8: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension Int16: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension Int32: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension Int64: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartUnsafeValue(self)] }
 }
+
 extension Date: SwifQLable {
     public var parts: [SwifQLPart] { [SwifQLPartDate(self)] }
 }
+
 extension Data: SwifQLable {
     public var parts: [SwifQLPart] {
         return [
@@ -78,12 +86,30 @@ extension Data: SwifQLable {
         ]
     }
 }
-public protocol SwifQLRawRepresentable: RawRepresentable, SwifQLable {}
-extension SwifQLRawRepresentable {
-    public var parts: [SwifQLPart] {
-        if let a = self.rawValue as? SwifQLable {
-            return a.parts
-        }
-        return []
+
+// MARK: - Protocols & Delegates
+// MARK: - Optional
+
+extension Optional: SwifQLable, CustomStringConvertible where Wrapped: SwifQLable {
+  public var parts: [SwifQLPart] {
+    switch self {
+      case .none:
+        return [SwifQLPartSafeValue(nil)]
+      case .some(let value):
+        return value.parts
     }
+  }
+}
+
+// MARK: - RawRepresentable
+
+public protocol SwifQLRawRepresentable: RawRepresentable, SwifQLable {}
+
+extension SwifQLRawRepresentable {
+
+    public var parts: [SwifQLPart] {
+      guard let a = self.rawValue as? SwifQLable else { return [] }
+      return a.parts
+    }
+
 }

--- a/Sources/SwifQL/Type.swift
+++ b/Sources/SwifQL/Type.swift
@@ -8,7 +8,7 @@
 typealias CastType = Type
 
 public struct Type {
-    let name: String
+    public let name: String
     
     public init (_ name: String) {
         self.name = name

--- a/SwifQL.podspec
+++ b/SwifQL.podspec
@@ -1,0 +1,26 @@
+
+Pod::Spec.new do |spec|
+
+    spec.name         = "SwifQL"
+    spec.version      = "2.1.0"
+
+    spec.summary      = "Super flexibel SQL query builder for server-side Swift"
+    spec.description  = """
+    This lib can be used either stand alone, or with frameworks like Vapor, Kitura, Perfect and others
+
+    We recommend to use it with our Bridges lib which is built on top of SwifQL and support all its flexibility
+
+    It supports PostgreSQL and MySQL. And it's not so hard to add other dialects 🙂 just check SwifQL/Dialect folder
+    """
+
+
+    spec.homepage = "https://github.com/SwifQL/SwifQL"
+    spec.author = { "MihaelIsaev" => "isaev.mihael@gmail.com" }
+    spec.license = { :type => "MIT", :file => "LICENSE" }
+
+    spec.swift_version = ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
+    # spec.platform = :osx, :ios
+    spec.source = { :git => "git@github.com:SwifQL/SwifQL.git", :tag => spec.version.to_s }
+    spec.source_files  = "Sources/SwifQL/**/*.swift"
+
+    end


### PR DESCRIPTION
Hello,

I've been working w/ SwifQL on an iOS app for the past year. For this app I needed to build `InfluxQL` queries, to request multiple time series databases.

SwifQL seems the best solutions available, allowing me to build request simply as a DSL, so first thanks for the great work.

I started building my own dialect inspired by the other dialect already available, unfortunately at some point I run into the issue of handling `regex` inside the query.

this is my working solution, mostly cleaned up and working on my side. it will probably need a little more work of cleaning.

But I wanted to offer a look at you guys maybe the feature could be added (handling regex), in any cases all feedback will be welcomed.